### PR TITLE
Exposing option to json encode or not

### DIFF
--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -44,12 +44,13 @@ class JsonMarshaller
     /**
      * Marshall an object into a json string
      * @param mixed $class the class object to marshall
+     * @param boolean $encode whether to json encode the result or not
      * @return string the json string
      * @throws JsonDecodeException
      */
-    public function marshall($class)
+    public function marshall($class, $encode = true)
     {
-        return $this->marshallClass($class, true);
+        return $this->marshallClass($class, $encode);
     }
 
     /**


### PR DESCRIPTION
My framework has output functionality that handles the json encoding.  I would like to add the ability to json_encode or not to the public marshall function so I do not have to decode the json only to encode the json again.  Thank you!  This is a great library - exactly what I was looking for!
