### PR TITLE
Adding ability to unmarshall using instance of class.  Adding marshall of null values.  Updating tests.

### DIFF
--- a/src/main/PhpJsonMarshaller/Decoder/ClassDecoder.php
+++ b/src/main/PhpJsonMarshaller/Decoder/ClassDecoder.php
@@ -129,14 +129,18 @@ class ClassDecoder
         }
 
         $methodName = $method->getName();
-        $subMethodName = substr($methodName, 0, 3);
+        preg_match('/[^A-Z]+/', lcfirst(str_replace(' ', '', ucwords(str_replace(['_'], ' ', $methodName)))), $matches);
+        $subMethodName = isset($matches[0]) ? $matches[0] : '';
 
-        if ($subMethodName === 'set') {
+        $setters = ['set', 'unmarshall'];
+        $getters = ['get', 'marshall'];
+
+        if (in_array($subMethodName, $setters, true)) {
             if ($classDecoderProperty->getSetter() !== null) {
                 throw new DuplicateAnnotationException("A @MarshallProperty annotation to set {$annotation->getName()} already exists in the class");
             }
             $classDecoderProperty->setSetter($methodName);
-        } elseif ($subMethodName === 'get'
+        } elseif (in_array($subMethodName, $getters, true)
             || (substr($annotation->getType(), 0, 4) === 'bool'
                 && in_array(preg_replace('/' . $annotation->getName() . '$/i', '', $methodName), ['is', 'should', 'can', 'has'])
             )

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -236,7 +236,7 @@ class JsonMarshaller
         $result = null;
 
         // Decode the value into our result
-        if ($value == null) {
+        if ($value === null) {
             $result = $value;
         } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
             $result = $propertyType->getValue()->decodeValue($value);

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -244,11 +244,11 @@ class JsonMarshaller
             $result = $this->unmarshallClass($value, $propertyType->getValue());
         } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_ARRAY) {
             $subPropertyType = $propertyType->getValue();
-            foreach ($value as $val) {
+            foreach ($value as $key => $val) {
                 if ($subPropertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
-                    $result[] = $subPropertyType->getValue()->decodeValue($val);
+                    $result[$key] = $subPropertyType->getValue()->decodeValue($val);
                 } else {
-                    $result[] = $this->unmarshallClass($val, $subPropertyType->getValue());
+                    $result[$key] = $this->unmarshallClass($val, $subPropertyType->getValue());
                 }
             }
         }

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -103,7 +103,9 @@ class JsonMarshaller
     {
         $result = null;
 
-        if ($propertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
+        if ($value === null) {
+            $result = $value;
+        } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
             $result = $propertyType->getValue()->encodeValue($value);
         } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_OBJECT) {
             $result = $this->marshallClass($value, false);

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -120,11 +120,11 @@ class JsonMarshaller
         } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_ARRAY) {
             $subResult = [];
             $subPropertyType = $propertyType->getValue();
-            foreach ($value as $val) {
+            foreach ($value as $key => $val) {
                 if ($subPropertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
-                    $subResult[] = $subPropertyType->getValue()->encodeValue($val);
+                    $subResult[$key] = $subPropertyType->getValue()->encodeValue($val);
                 } else {
-                    $subResult[] = $this->marshallClass($val, false);
+                    $subResult[$key] = $this->marshallClass($val, false);
                 }
             }
             $result = $subResult;
@@ -244,11 +244,11 @@ class JsonMarshaller
             $result = $this->unmarshallClass($value, $propertyType->getValue());
         } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_ARRAY) {
             $subPropertyType = $propertyType->getValue();
-            foreach ($value as $val) {
+            foreach ($value as $key => $val) {
                 if ($subPropertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
-                    $result[] = $subPropertyType->getValue()->decodeValue($val);
+                    $result[$key] = $subPropertyType->getValue()->decodeValue($val);
                 } else {
-                    $result[] = $this->unmarshallClass($val, $subPropertyType->getValue());
+                    $result[$key] = $this->unmarshallClass($val, $subPropertyType->getValue());
                 }
             }
         }

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -169,6 +169,10 @@ class JsonMarshaller
     protected function unmarshallClass($assocArray, $class)
     {
 
+        if ($assocArray === null || $assocArray === 'null' || $assocArray === '') {
+            return null;
+        }
+
         $classString = is_object($class) ? get_class($class) : $class;
 
         // Decode the class and it's properties

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -236,7 +236,9 @@ class JsonMarshaller
         $result = null;
 
         // Decode the value into our result
-        if ($propertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
+        if ($value == null) {
+            $result = $value;
+        } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_SCALAR) {
             $result = $propertyType->getValue()->decodeValue($value);
         } elseif ($propertyType->getType() === PropertyTypeObject::TYPE_OBJECT) {
             $result = $this->unmarshallClass($value, $propertyType->getValue());

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -197,7 +197,20 @@ class JsonMarshaller
                 if ($property->hasDirect()) {
                     $classInstance->{$property->getDirect()} = $result;
                 } elseif ($property->hasSetter()) {
-                    $classInstance->{$property->getSetter()}($result);
+                    $setter = $property->getSetter();
+                    if($propertyType->getType() == 'array') {
+                        $reflection = new \ReflectionMethod($classInstance, $setter);
+                        if($reflection->getParameters()[0]->isVariadic()) {
+                            $result = is_array($result) && $result ? $result : [];
+                            $classInstance->{$setter}(...$result);
+                        }
+                        else {
+                            $classInstance->{$setter}($result);
+                        }
+                    }
+                    else {
+                        $classInstance->{$setter}($result);
+                    }
                 }
             } else {
                 if ($decodedClass->canIgnoreUnknown() === false) {

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -76,18 +76,26 @@ class JsonMarshaller
         $result = [];
 
         foreach ($decodedClass->getProperties() as $property) {
-            $value = null;
-            $propertyType = $property->getPropertyType();
 
-            // Get the value from the class
-            if ($property->hasDirect()) {
-                $value = $class->{$property->getDirect()};
-            } elseif ($property->hasGetter()) {
-                $value = $class->{$property->getGetter()}();
+            $hasDirect = $property->hasDirect();
+            $hasGetter = $property->hasGetter();
+
+            if($hasDirect || $hasGetter) {
+
+                $value = null;
+                $propertyType = $property->getPropertyType();
+
+                // Get the value from the class
+                if ($hasDirect) {
+                    $value = $class->{$property->getDirect()};
+                } elseif ($hasGetter) {
+                    $value = $class->{$property->getGetter()}();
+                }
+
+                // Encode it into our json result
+                $result[$property->getAnnotationName()] = $this->encodeValue($value, $propertyType);
+
             }
-
-            // Encode it into our json result
-            $result[$property->getAnnotationName()] = $this->encodeValue($value, $propertyType);
         }
 
         return ($encode ? json_encode($result) : $result);

--- a/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
+++ b/src/main/PhpJsonMarshaller/Marshaller/JsonMarshaller.php
@@ -145,9 +145,6 @@ class JsonMarshaller
         if (json_last_error() !== 0) {
             throw new JsonDecodeException('Could not decode the JSON string');
         }
-        if (empty($assocArray)) {
-            throw new \InvalidArgumentException('You cannot unmarshall an empty string');
-        }
 
         return $this->unmarshallClass($assocArray, $class);
     }

--- a/src/main/PhpJsonMarshaller/Type/BoolType.php
+++ b/src/main/PhpJsonMarshaller/Type/BoolType.php
@@ -32,10 +32,10 @@ class BoolType implements iType
         if (is_object($value) || is_array($value)) {
             throw new InvalidTypeException("Expected boolean but received " . gettype($value));
         }
-        if ($value === 'true' || $value === 1) {
+        if ($value === 'true' || $value === '1' || $value === 1) {
             return true;
         }
-        if ($value === 'false' || $value === 0) {
+        if ($value === 'false' || $value === '0' || $value === 0) {
             return false;
         }
         throw new InvalidTypeException("Expected boolean but received " . gettype($value));

--- a/src/tests/PhpJsonMarshallerTests/Cache/CacheTest.php
+++ b/src/tests/PhpJsonMarshallerTests/Cache/CacheTest.php
@@ -46,7 +46,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($fromCache->hasProperty('active'));
         $this->assertTrue($fromCache->hasProperty('firstLogin'));
         $this->assertTrue($fromCache->hasProperty('rank'));
-        $this->assertTrue($fromCache->hasProperty('address'));
+        $this->assertTrue($fromCache->hasProperty('homeAddress'));
         $this->assertTrue($fromCache->hasProperty('flags'));
         $this->assertTrue($fromCache->hasProperty('loginDates'));
     }

--- a/src/tests/PhpJsonMarshallerTests/ExampleClass/User.php
+++ b/src/tests/PhpJsonMarshallerTests/ExampleClass/User.php
@@ -51,9 +51,15 @@ class User
 
     /**
      * @var Address
-     * @MarshallProperty(name="address", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     * @MarshallProperty(name="homeAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
      */
-    protected $address;
+    protected $homeAddress;
+
+    /**
+     * @var Address
+     * @MarshallProperty(name="workAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     */
+    protected $workAddress;
 
     /**
      * @var Flag[]
@@ -167,20 +173,38 @@ class User
 
     /**
      * @return Address
-     * @MarshallProperty(name="address", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     * @MarshallProperty(name="homeAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
      */
-    public function getAddress()
+    public function getHomeAddress()
     {
-        return $this->address;
+        return $this->homeAddress;
     }
 
     /**
      * @param Address $address
-     * @MarshallProperty(name="address", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     * @MarshallProperty(name="homeAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
      */
-    public function setAddress($address)
+    public function setHomeAddress($address)
     {
-        $this->address = $address;
+        $this->homeAddress = $address;
+    }
+
+    /**
+     * @return Address
+     * @MarshallProperty(name="workAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     */
+    public function getWorkAddress()
+    {
+        return $this->workAddress;
+    }
+
+    /**
+     * @param Address $address
+     * @MarshallProperty(name="workAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     */
+    public function setWorkAddress($address)
+    {
+        $this->workAddress = $address;
     }
 
     /**

--- a/src/tests/PhpJsonMarshallerTests/ExampleClass/UserAlternate.php
+++ b/src/tests/PhpJsonMarshallerTests/ExampleClass/UserAlternate.php
@@ -27,9 +27,15 @@ class UserAlternate
 
     /**
      * @var Address
-     * @MarshallProperty(name="address", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     * @MarshallProperty(name="homeAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
      */
-    public $address;
+    public $homeAddress;
+
+    /**
+     * @var Address
+     * @MarshallProperty(name="workAddress", type="\PhpJsonMarshallerTests\ExampleClass\Address")
+     */
+    public $workAddress;
 
     /**
      * @var Flag[]

--- a/src/tests/PhpJsonMarshallerTests/ExampleJson/ComplexKeyValueArrayObject.json
+++ b/src/tests/PhpJsonMarshallerTests/ExampleJson/ComplexKeyValueArrayObject.json
@@ -4,7 +4,7 @@
     "active": true,
     "firstLogin": "2015-08-12 11:45:32",
     "rank": 5.5,
-    "address": {
+    "homeAddress": {
         "id": 1,
         "street": "123 Main Street",
         "state": "California",

--- a/src/tests/PhpJsonMarshallerTests/Marshaller/JsonMarshallerTest.php
+++ b/src/tests/PhpJsonMarshallerTests/Marshaller/JsonMarshallerTest.php
@@ -144,7 +144,7 @@ class JsonMarshallerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($json['firstName'], $user->getFirstName());
         $this->assertSame($json['active'], $user->isActive());
         $this->assertEquals(new \DateTime($json['firstLogin']), $user->getFirstLogin());
-        $this->assertSame($json['address']['id'], $user->getAddress()->id);
+        $this->assertSame($json['homeAddress']['id'], $user->getHomeAddress()->id);
         $this->assertSame($json['flags'][0]['id'], $user->getFlags()[0]->id);
         $this->assertEquals(new \DateTime($json['loginDates'][0]), $user->getLoginDates()[0]);
     }
@@ -157,7 +157,7 @@ class JsonMarshallerTest extends \PHPUnit_Framework_TestCase
         $user = $this->marshaller->unmarshall($this->complexKeyValueArrayObject, 'PhpJsonMarshallerTests\ExampleClass\UserAlternate');
 
         $this->assertSame($json['id'], $user->id);
-        $this->assertSame($json['address']['id'], $user->address->id);
+        $this->assertSame($json['homeAddress']['id'], $user->homeAddress->id);
         $this->assertSame($json['flags'][0]['id'], $user->flags[0]->id);
     }
 
@@ -225,7 +225,7 @@ class JsonMarshallerTest extends \PHPUnit_Framework_TestCase
         $user->setActive(true);
         $user->setFirstLogin(new \DateTime('2015-08-12 11:45:32'));
         $user->setRank(5.5);
-        $user->setAddress($address);
+        $user->setHomeAddress($address);
         $user->setFlags([$flag1, $flag2]);
         $user->setLoginDates([
             new \DateTime('2015-08-12 11:40:00'),
@@ -265,17 +265,18 @@ class JsonMarshallerTest extends \PHPUnit_Framework_TestCase
 
         $user = new UserAlternate();
         $user->id = 12345;
-        $user->address = $address;
+        $user->homeAddress = $address;
         $user->flags = [$flag1, $flag2];
 
         $json = $this->marshaller->marshall($user);
         $decoded = json_decode($json, true);
 
         $this->assertEquals($user->id, $decoded['id']);
-        $this->assertEquals($user->address->id, $decoded['address']['id']);
-        $this->assertEquals($user->address->state, $decoded['address']['state']);
-        $this->assertEquals($user->address->street, $decoded['address']['street']);
-        $this->assertEquals($user->address->zip, $decoded['address']['zipcode']);
+        $this->assertEquals($user->homeAddress->id, $decoded['homeAddress']['id']);
+        $this->assertEquals($user->homeAddress->state, $decoded['homeAddress']['state']);
+        $this->assertEquals($user->homeAddress->street, $decoded['homeAddress']['street']);
+        $this->assertEquals($user->homeAddress->zip, $decoded['homeAddress']['zipcode']);
+        $this->assertEquals($user->workAddress, null);
         $this->assertEquals($user->flags[0]->id, $decoded['flags'][0]['id']);
         $this->assertEquals($user->flags[0]->name, $decoded['flags'][0]['name']);
         $this->assertEquals($user->flags[0]->value, $decoded['flags'][0]['value']);


### PR DESCRIPTION
Hello again, Anuj.

In some cases, I like to be able to overwrite data of existing objects.  For instance, in PATCH requests.

I have made a modification that allows an existing object to be passed to unmarshall.

Here is how I am using it:

```
  /**
   * Update the specified resource in storage.
   *
   * @param  int $id
   * @return \Illuminate\Http\Response
   */
  public function update($id) {

    $parameters = (new SingleOrganizationSearchParameters())->setUuid($id);
    $organization = $this->data->getOrganization($parameters);

    /**
     * @var OrganizationEntity $organization
     */
    $organization = $this->marshaller->unmarshall($organization);
    $updated = $this->data->updateOrganization($organization);
    return $this->respondData($this->marshaller->marshall($updated));

  }
```

I think this would be a useful feature for the library.  Let me know what you think.

---

Additionally, I have also added the ability to marshall null values.  In some instances, nested JSON can represent a related resource that may not be present.

Let's take for instance, the `User` class in the test cases.  Perhaps the user contains two addresses - a home address and a work address.  Perhaps the user does not have a work address.  It would make sense to me that the getUser() function should return null and that null value should be marshalled as null.  Prior to this commit, it was not possible to return null because a class was expected as defined in the docblock.  However, I believe that null should be possible because null responses IMO are more convenient to read from an API client perspective.

For instance, to me, this JSON:

```
{
    "home_address": {
      "id": "95780d40-544d-11e6-8b03-5181b1ace9f4",
      "street": "1 Main St.",
      "state", "NV",
      "zip": "89501"
    },
    "work_address": null
}

```

Is preferable to this JSON:

```
{
    "home_address": {
      "id": "95780d40-544d-11e6-8b03-5181b1ace9f4",
      "street": "1 Main St.",
      "state", "NV",
      "zip": "89501"
    },
    "work_address": {
      "id": "",
      "street": "",
      "state", "",
      "zip": ""
    }
}
```

I have further updated the test cases to reflect this change.

Thank You,
Josh
